### PR TITLE
Add --local and --remote arguments to 'juicer cart delete'. #23

### DIFF
--- a/docsite/source/conf.py
+++ b/docsite/source/conf.py
@@ -147,7 +147,7 @@ html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
+html_last_updated_fmt = '%Y-%m-%d - %H:%M:%S %Z'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.

--- a/docsite/source/conf.py
+++ b/docsite/source/conf.py
@@ -147,7 +147,7 @@ html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-html_last_updated_fmt = '%Y-%m-%d - %H:%M:%S %Z'
+#html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.

--- a/docsite/source/conf.py.in
+++ b/docsite/source/conf.py.in
@@ -147,7 +147,7 @@ html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
+html_last_updated_fmt = '%Y-%m-%d - %H:%M:%S %Z'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.

--- a/docsite/source/getting_started.rst
+++ b/docsite/source/getting_started.rst
@@ -154,12 +154,12 @@ environment.
    enable remote saves. Remote carts can be pulled with ``juicer cart
    pull``.
 
-   To further illustrate remote cart saving, we can delete our local cart
-   file and pull it down again.
+   To further illustrate remote cart saving, we can delete our local
+   cart and pull it down again.
 
    .. code:: bash
 
-      rm ~/.config/juicer/carts/my-cart.json
+      juicer cart delete my-cart --local
       juicer cart pull my-cart
       juicer cart show my-cart
 

--- a/juicer.1
+++ b/juicer.1
@@ -2,12 +2,12 @@
 .\"     Title: juicer
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
-.\"      Date: 06/05/2015
+.\"      Date: 06/07/2015
 .\"    Manual: Pulp repos and release carts
 .\"    Source: Juicer 1.0.0
 .\"  Language: English
 .\"
-.TH "JUICER" "1" "06/05/2015" "Juicer 1\&.0\&.0" "Pulp repos and release carts"
+.TH "JUICER" "1" "06/07/2015" "Juicer 1\&.0\&.0" "Pulp repos and release carts"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -91,13 +91,23 @@ Items to add to the cart in repository
 .RE
 .SS "CART DELETE"
 .sp
-usage: juicer cart delete \fICARTNAME\fR
+usage: juicer cart delete \fICARTNAME\fR [\-l,\-\-local] [\-r,\-\-remote]
 .sp
-Deletes a release cart from your local system and on the cart server\&.
+Delete a juicer cart\&. Default behavior deletes any locally cached copies as well as remote copies stored in MongoDB\&.
 .PP
 \fBCARTNAME\fR
 .RS 4
 The name of the release cart to delete\&.
+.RE
+.PP
+\fB\-l,\-\-local\fR
+.RS 4
+Delete the cart which is cached locally (does not destroy remote cart definitions)
+.RE
+.PP
+\fB\-r,\-\-remote\fR
+.RS 4
+Delete the cart on the remote side only (ignores any cached cart definitions)\&.
 .RE
 .SS "CART LIST"
 .sp

--- a/juicer.1.asciidoc.in
+++ b/juicer.1.asciidoc.in
@@ -70,12 +70,21 @@ Items to add to the cart in repository 'REPONAME'.
 
 CART DELETE
 ~~~~~~~~~~~
-usage: juicer cart delete 'CARTNAME'
+usage: juicer cart delete 'CARTNAME' [-l,--local] [-r,--remote]
 
-Deletes a release cart from your local system and on the cart server.
+Delete a juicer cart. Default behavior deletes any locally cached
+copies as well as remote copies stored in MongoDB.
 
 *CARTNAME*::
 The name of the release cart to delete.
+
+*-l,--local*::
+Delete the cart which is cached locally (does not destroy remote cart
+definitions)
+
+*-r,--remote*::
+Delete the cart on the remote side only (ignores any cached cart
+definitions).
 
 
 CART LIST

--- a/juicer/command/cart.py
+++ b/juicer/command/cart.py
@@ -37,8 +37,8 @@ class CartDeleteCommand(JuicerCommand):  # pragma: no cover
 
     def run(self):
         cart = juicer.cart.Cart(self.args.cartname)
-        cart.delete()
-        self.output.info("Successfully deleted cart {}".format(cart.name))
+        cart.delete(local=self.args.local,
+                    remote=self.args.remote)
 
 
 class CartListCommand(JuicerCommand):

--- a/juicer/parser/Parser.py
+++ b/juicer/parser/Parser.py
@@ -169,7 +169,7 @@ class Parser(object):
         # Create the 'cart push' sub-parser
         parser_cart_push = subparser_cart.add_parser('push',
                                                      help='upload cart items to pulp',
-                                                     usage='%(prog)s CARTNAME [--in ENV [ENV ...]] [-f] [-h]')
+                                                     usage='%(prog)s CARTNAME [--in ENV [ENV ...]] [-f,--force] [-h]')
 
         parser_cart_push.add_argument('cartname', metavar='CARTNAME',
                                       help='cart name')
@@ -192,10 +192,22 @@ class Parser(object):
         # Create the 'cart delete' sub-parser
         parser_cart_delete = subparser_cart.add_parser('delete',
                                                        help='delete cart locally and on remote',
-                                                       usage='%(prog)s CARTNAME [-h]')
+                                                       usage='%(prog)s CARTNAME [-l,--local] [-r,--remote] [-h]')
 
         parser_cart_delete.add_argument('cartname', metavar='CARTNAME',
                                         help='cart name')
+
+        parser_cart_delete.add_argument('-l', '--local',
+                                        action='store_true',
+                                        default=False,
+                                        dest='local',
+                                        help='delete the cart which is cached locally (does not destroy remote cart definitions)')
+
+        parser_cart_delete.add_argument('-r', '--remote',
+                                        action='store_true',
+                                        default=False,
+                                        dest='remote',
+                                        help='delete the cart on the remote side only (ignores any cached cart definitions)')
 
         parser_cart_delete.set_defaults(cmd=juicer.command.cart.CartDeleteCommand)
 


### PR DESCRIPTION
The default behavior of 'juicer cart delete' will delete local and
remote cart data. This behavior can be overridden by specifying only
--local to delete the cart locally, specifying only --remote to delete
the cart remotely OR both can be specified which follows default
behavior.