### PR TITLE
Save cart on remote during create

### DIFF
--- a/juicer.1
+++ b/juicer.1
@@ -2,12 +2,12 @@
 .\"     Title: juicer
 .\"    Author: [see the "AUTHOR" section]
 .\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
-.\"      Date: 06/12/2015
+.\"      Date: 07/28/2015
 .\"    Manual: Pulp repos and release carts
 .\"    Source: Juicer 1.0.0
 .\"  Language: English
 .\"
-.TH "JUICER" "1" "06/12/2015" "Juicer 1\&.0\&.0" "Pulp repos and release carts"
+.TH "JUICER" "1" "07/28/2015" "Juicer 1\&.0\&.0" "Pulp repos and release carts"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -66,7 +66,7 @@ in their usage line\&.
 .SH "CART OPERATIONS"
 .SS "CART CREATE"
 .sp
-usage: juicer cart create \fICARTNAME\fR [\-r \fIREPONAME\fR \fIITEM\fR \&... [\-r \fIREPONAME\fR \fIITEM\fR \&...]]
+usage: juicer cart create \fICARTNAME\fR [\-r \fIREPONAME\fR \fIITEM\fR \&... [\-r \fIREPONAME\fR \fIITEM\fR \&...]] [\-f,\-\-force]
 .sp
 Create a cart with the items specified\&. Creating a cart will overwrite a local cart if any local cart shares a name with the cart being created\&.
 .PP
@@ -97,6 +97,11 @@ The type of cart to create,
 \fIdocker\fR, or
 \fIiso\fR\&. Defaults to
 \fIrpm\fR\&.
+.RE
+.PP
+\fB\-f,\-\-force\fR
+.RS 4
+Force push cart\&. Force must be used when local cart differs from cart server\&.
 .RE
 .SS "CART DELETE"
 .sp
@@ -141,7 +146,7 @@ The name of the cart to pull\&.
 .RE
 .SS "CART PUSH"
 .sp
-usage: juicer cart push \fICARTNAME\fR [\-f] [\-\-in ENV [ENV \&...]]
+usage: juicer cart push \fICARTNAME\fR [\-\-in ENV [ENV \&...]] [\-f,\-\-force]
 .sp
 Pushes all cart items their repositories\&. Saves cart on the cart server\&.
 .PP

--- a/juicer.1.asciidoc.in
+++ b/juicer.1.asciidoc.in
@@ -53,7 +53,7 @@ CART OPERATIONS
 
 CART CREATE
 ~~~~~~~~~~~
-usage: juicer cart create 'CARTNAME' [-r 'REPONAME' 'ITEM' ... [-r 'REPONAME' 'ITEM' ...]]
+usage: juicer cart create 'CARTNAME' [-r 'REPONAME' 'ITEM' ... [-r 'REPONAME' 'ITEM' ...]] [-f,--force]
 
 Create a cart with the items specified. Creating a cart will overwrite
 a local cart if any local cart shares a name with the cart being
@@ -72,6 +72,10 @@ Items to add to the cart in repository 'REPONAME'.
 *-t,--type* 'CART-TYPE'::
 The type of cart to create, 'rpm', 'docker', or 'iso'. Defaults
 to 'rpm'.
+
+*-f,--force*::
+Force push cart. Force must be used when local cart differs from cart
+server.
 
 
 CART DELETE
@@ -120,7 +124,7 @@ The name of the cart to pull.
 
 CART PUSH
 ~~~~~~~~~
-usage: juicer cart push 'CARTNAME' [-f] [--in ENV [ENV ...]]
+usage: juicer cart push 'CARTNAME' [--in ENV [ENV ...]] [-f,--force]
 
 Pushes all cart items their repositories. Saves cart on the cart
 server.

--- a/juicer/command/cart.py
+++ b/juicer/command/cart.py
@@ -29,7 +29,8 @@ def CartCreateCommand(args):  # pragma: no cover
     juicer.cart.Cart(name=jc.args.cartname,
                      cart_type=jc.args.cart_type,
                      description=filtered_repo_items,
-                     autosave=True)
+                     autosave=True,
+                     force=jc.args.force)
 
 
 def CartDeleteCommand(args):  # pragma: no cover

--- a/juicer/parser/Parser.py
+++ b/juicer/parser/Parser.py
@@ -101,7 +101,7 @@ class Parser(object):
         # Create the 'cart create' sub-parser
         parser_cart_create = subparser_cart.add_parser('create',
                                                        help='create cart with destination repositories and items',
-                                                       usage='%(prog)s CARTNAME [-r REPONAME ITEM ... [-r REPONAME ITEM ...]] [-t,-type CART-TYPE]')
+                                                       usage='%(prog)s CARTNAME [-r REPONAME ITEM ... [-r REPONAME ITEM ...]] [-t,-type CART-TYPE] [-f,--force]')
 
         parser_cart_create.add_argument('cartname', metavar='CARTNAME',
                                         help='cart name')
@@ -118,6 +118,12 @@ class Parser(object):
                                         default="rpm",
                                         dest='cart_type',
                                         help='type of cart items (one of: rpm, docker, iso)(default: rpm)')
+
+        parser_cart_create.add_argument('-f', '--force',
+                                        action='store_true',
+                                        default=False,
+                                        dest='force',
+                                        help='force create')
 
         parser_cart_create.set_defaults(cmd=juicer.command.cart.CartCreateCommand)
 

--- a/test/test_cart.py
+++ b/test/test_cart.py
@@ -74,7 +74,7 @@ class TestCart(TestCase):
                                     description={'test-repo': ['share/juicer/empty-0.1-1.noarch.rpm']})
 
             # We can save the cart and a file is created locally.
-            cart.save()
+            cart.save(force=True)
             self.assertTrue(os.path.exists(cart.cart_file))
             # We can delete the cart and the file no longer exists.
             cart.delete()
@@ -87,7 +87,7 @@ class TestCart(TestCase):
             constants.USER_CONFIG = './config'
             cart = juicer.cart.Cart(name='test-cart',
                                     description={'test-repo': []})
-            cart.save()
+            cart.save(force=True)
             self.assertFalse(os.path.exists(cart.cart_file))
         
     def test_cart_update(self):


### PR DESCRIPTION
This PR introduces cart save on local/remote by default. Cart names are cross checked w/ remote and if a cart already exists with the same name then --force must be used.

This would wrap #23 as it eliminates the need to do a thin cart push since creating a cart saves it on the remote by default.

Must have `cart_seeds` in your config for this to even be attempted.
